### PR TITLE
fix: correct author email

### DIFF
--- a/apermo-adminbar.php
+++ b/apermo-adminbar.php
@@ -19,7 +19,7 @@
 
 /**
  * Apermo AdminBar
- * Copyright (C) 2016, Christoph Daum - info@apermo.de
+ * Copyright (C) 2016, Christoph Daum - me@christoph-daum.de
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Replace `info@apermo.de` with `me@christoph-daum.de`.